### PR TITLE
Create reference_researcher_playbook.md

### DIFF
--- a/en/reference_researcher_playbook.md
+++ b/en/reference_researcher_playbook.md
@@ -1,0 +1,51 @@
+# SCRF: Reference - Researcher Playbook
+
+
+## SCRF Mandate
+
+The Smart Contract Research Forum (SCRF) is the premiere space to find, share, and discuss emerging research in blockchain technologies. We connect academics, researchers, and industry leaders from all over the world to share research, solicit thoughtful peer review, and find new projects to collaborate on.
+
+The success of SCRF rests on whether or not we can provide value to academics, engineers, industry, and researchers. To ensure external validity, we invite discourse from a wide variety of academic disciplines, chains, professions, and backgrounds. We must constantly check ourselves against the demands of the community and beyond and, if necessary, realign to ensure we’re connecting with our peers. 
+
+We adhere closely to the ethos of the open-source software community. Anyone should be able to contribute as much time, effort, and ideas as they wish, provided it aligns with SCRF’s mission of bridging the gap between academia and industry. We welcome ideas for projects and new research and have implemented several frameworks for ensuring that they meet our standards. We also want to encourage collaboration and the creation of new work: there are grants, honoraria, and other forms of compensation available.
+
+## Description
+
+This playbook is a public document that explains the best practices for researcher writing, tone, and discussion of topics on the forum. It is intended to lay out an easy to follow guide to help researchers be content/discussion leaders and uphold the high-minded discourse valued by the forum. Additionally, it is public so that the community is able to reference the spirit of research content and discourse in their own contributions to the forum. 
+
+This is a living document that will be updated to reflect emerging best practices and approaches to content on the forum. 
+
+## Motivation
+
+The goal of the forum is to produce high-quality discussions about rigorous research and pragmatic problem-solving. In order to produce this high-quality discussion, engagement on the forum is the primary goal. Our content creation motivation is to facilitate high-level quality discussion by:
+- Emphasizing content that is novel, relevant, and timely
+    - Our content should represent the best thinking and most informative concepts and designs in the crypto space. 
+- Presenting content so that it is easy to consume, use, and engage with
+    - Writing on the forum should ideally take educational and potentially complex information and present it in a way that is accessible to our target audiences (researchers, engineers, and other related professionals). 
+- Adhering to standards of evidence-based content
+    - Posts and comments should all be encouraged to make use of and cite evidence. Personal experience is certainly valuable, but we should encourage people to buttress those experiences with external evidence that helps them solidify their point. 
+- Maintaining accuracy and correctness of the content:
+    - The forum is seeking to identify the most accurate and factual information available. This may change over time (some good information becomes out of date, for example), but the goal should be to encourage people to seek quality information, not just information that reinforces their point. Our job is to help facilitate discussions that surface good information.
+
+These motivations should guide the type of content that is produced for the forum. 
+
+## Tone
+
+It is our goal to have a consistent tone on the forum. In order to achieve our goals of having high quality discussions, we seek to establish a tone that follows these characteristics:
+
+-   Using language that is precise
+-   Using language that is approachable manner for all audiences
+-   Describing concepts in an unbiased manner
+-   Civil (even in critique or disagreement)
+-   Encouraging and supportive of other SCRF members
+-   Open-minded to conflicting viewpoints
+-   Substantive and seeks to deliver content that is educational and informative to readers
+-   Honest about the positive and negative aspects of concepts being discussed
+
+## Focus
+
+We think there are four fundamental properties when it comes to determining whether we should be covering a piece of research: 
+- Complexity: What are the conceptual building blocks required to have a discussion about this topic? Can most industry engineers understand this and, if they can’t, what must they know before they can?
+- Applicability: How applicable is the topic at hand? Does it have industry-wide repercussions? 
+- Novelty: Are novel ideas being presented in light of what has already been published on this topic?
+- Timeliness: Are industry participants currently discussing this topic? Has it been discussed recently?


### PR DESCRIPTION
This playbook is a public document that explains the best practices for researcher writing, tone, and discussion of topics on the forum.